### PR TITLE
Fixes #3 - Add option to skip the prompted step

### DIFF
--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -24,6 +24,7 @@ module ForemanMaintain
   require 'foreman_maintain/runner'
   require 'foreman_maintain/reporter'
   require 'foreman_maintain/utils'
+  require 'foreman_maintain/error'
 
   class << self
     attr_accessor :config, :logger

--- a/lib/foreman_maintain/check.rb
+++ b/lib/foreman_maintain/check.rb
@@ -37,7 +37,7 @@ module ForemanMaintain
     # internal method called by executor
     def __run__(execution)
       super
-    rescue Fail => e
+    rescue Error::Fail => e
       execution.status = :fail
       execution.output << e.message
     end

--- a/lib/foreman_maintain/error.rb
+++ b/lib/foreman_maintain/error.rb
@@ -1,0 +1,6 @@
+module ForemanMaintain
+  module Error
+    class Fail < StandardError
+    end
+  end
+end

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -22,12 +22,16 @@ module ForemanMaintain
       @reporter.after_scenario_finishes(@scenario)
     end
 
-    def ask_to_quit
+    def ask_to_quit(_step = nil)
       @quit = true
     end
 
     def add_step(step)
       @steps_to_run.unshift(step)
+    end
+
+    def skip_to_next(step)
+      prepend_next_steps_if_any(step)
     end
 
     private
@@ -37,6 +41,12 @@ module ForemanMaintain
         steps = steps.map(&:ensure_instance)
         @reporter.on_next_steps(self, steps)
       end
+    end
+
+    def prepend_next_steps_if_any(step)
+      @steps_to_run.unshift(*step.next_steps) if step.next_steps
+    rescue
+      nil
     end
   end
 end

--- a/lib/foreman_maintain/runner/execution.rb
+++ b/lib/foreman_maintain/runner/execution.rb
@@ -37,6 +37,10 @@ module ForemanMaintain
         @status == :fail
       end
 
+      def skipped?
+        @status == :skipped
+      end
+
       def run
         @status = :running
         @reporter.before_execution_starts(self)

--- a/test/lib/runner_test.rb
+++ b/test/lib/runner_test.rb
@@ -28,5 +28,33 @@ module ForemanMaintain
                    reporter.log,
                    'unexpected order of execution')
     end
+
+    describe 'skip_to_next' do
+      let(:scenario) { Scenarios::Deploy.new }
+      let(:runner) { Runner.new(reporter, scenario) }
+      let(:step) { Procedures::DeleteArticles::OneYearOld.new }
+
+      it 'should mock a skip class' do
+        mocked_class = MiniTest::Mock.new
+        runner.stubs(:mock_skip_class).with(step).returns([mocked_class])
+
+        runner.skip_to_next(step)
+      end
+
+      it 'executes next_steps(if any)' do
+        scenario.steps.pop
+        steps_to_run = runner.skip_to_next(step)
+
+        assert_equal(1, steps_to_run.count)
+      end
+
+      it 'does not adds next_steps if raises error' do
+        scenario.steps.pop
+        current_step = runner.skip_to_next(step).pop
+        steps_to_run = runner.skip_to_next(current_step.new)
+
+        refute(steps_to_run)
+      end
+    end
   end
 end

--- a/test/lib/support/definitions/features/delete_articles.rb
+++ b/test/lib/support/definitions/features/delete_articles.rb
@@ -1,0 +1,17 @@
+class Features::DeleteArticles < ForemanMaintain::Feature
+  metadata do
+    label :delete_articles
+
+    confine do
+      true
+    end
+  end
+
+  def one_year_old
+    say 'Deleted tasks in planning state'
+  end
+
+  def with_zero_comments
+    say 'Deleted tasks 30 days old'
+  end
+end

--- a/test/lib/support/definitions/procedures/delete_articles/one_year_old.rb
+++ b/test/lib/support/definitions/procedures/delete_articles/one_year_old.rb
@@ -1,0 +1,17 @@
+module Procedures::DeleteArticles
+  class OneYearOld < ForemanMaintain::Procedure
+    metadata do
+      for_feature(:delete_articles)
+      tags :release
+      description 'Delete all articles created 1 year ago'
+    end
+
+    def run
+      feature(:task_articles).one_year_old
+    end
+
+    def next_steps
+      [procedure(Procedures::DeleteArticles::WithZeroComments)]
+    end
+  end
+end

--- a/test/lib/support/definitions/procedures/delete_articles/with_zero_comments.rb
+++ b/test/lib/support/definitions/procedures/delete_articles/with_zero_comments.rb
@@ -1,0 +1,16 @@
+module Procedures::DeleteArticles
+  class WithZeroComments < ForemanMaintain::Procedure
+    metadata do
+      for_feature(:delete_articles)
+      description 'Delete all articles with zero comments'
+    end
+
+    def run
+      feature(:delete_articles).with_zero_comments
+    end
+
+    def next_steps
+      [procedure(:non_existing_procedure)] if fail?
+    end
+  end
+end

--- a/test/lib/support/definitions/scenarios/deploy.rb
+++ b/test/lib/support/definitions/scenarios/deploy.rb
@@ -1,0 +1,15 @@
+class Scenarios::Deploy < ForemanMaintain::Scenario
+  metadata do
+    confine do
+      feature(:delete_articles)
+    end
+
+    tags :release
+
+    description 'Scenario: Deploy application'
+  end
+
+  def compose
+    steps.concat(find_procedures(:release))
+  end
+end


### PR DESCRIPTION
* When opted to skip(choice: 'N', 'n' or 'no')
  * Check if any next_steps exists, prepend to `steps_to_run` array
  * Run the next check
* Add 'next' or 'no' option for multiple steps

_Looks like:_
```ruby
sat62 :: ~/foreman_maintain ‹3-option-to-skip-step*› » ./bin/foreman-maintain upgrade check 6.2.z                                                                                                              
Running checks before upgrading to Satellite 6.2.z
--------------------------------------------------------------------------------
Check for recommended disk speed of pulp, mongodb, pgsql dir.:        [OK]
--------------------------------------------------------------------------------
check for paused tasks:                                               [FAIL]
There are currently 5 paused tasks in the system
--------------------------------------------------------------------------------
Continue with step [resume paused tasks]?, [y(yes), n(no), q(quit)]n
--------------------------------------------------------------------------------
check for running tasks:                                              [OK]
--------------------------------------------------------------------------------
```