### PR TITLE
Allow running checks by label

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ enough to provide the right tools for the specific version.
 ```
 Subcommands:
     health                        Health related commands
-      list-checks                   List the checks based on criteria
+      list                          List the checks based on criteria
       list-tags                     List the tags to use for filtering checks
       check                         Run the health checks against the system
-        --tags tags                   Limit only for specific set of tags
+        --label label               Run only a specific check
+        --tags tags                 Limit only for specific set of tags
 
     upgrade                       Upgrade related commands
       list-versions                List versions this system is upgradable to

--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -37,8 +37,18 @@ module ForemanMaintain
         collection.inject([]) { |array, check| array.concat(check.tags).uniq }.sort_by(&:to_s)
       end
 
+      def self.label_option
+        option '--label', 'label',
+               'Limit only for a specific label. ' \
+                 '(Use "list" command to see available labels)' do |label|
+          underscorize(label).to_sym
+        end
+      end
+
       def self.tags_option
-        option '--tags', 'tags', 'Limit only for specific set of tags' do |tags|
+        option '--tags', 'tags',
+               'Limit only for specific set of labels. ' \
+                 '(Use list-tags command to see available tags)' do |tags|
           tags.split(',').map(&:strip).map { |tag| underscorize(tag).to_sym }
         end
       end

--- a/lib/foreman_maintain/cli/health_command.rb
+++ b/lib/foreman_maintain/cli/health_command.rb
@@ -1,7 +1,7 @@
 module ForemanMaintain
   module Cli
     class HealthCommand < Base
-      subcommand 'list-checks', 'List the checks based on criteria' do
+      subcommand 'list', 'List the checks based on criteria' do
         tags_option
 
         def execute
@@ -28,10 +28,33 @@ module ForemanMaintain
       end
 
       subcommand 'check', 'Run the health checks against the system' do
+        label_option
         tags_option
 
         def execute
-          run_scenario(Scenario::ChecksScenario.new(tags || [:basic]))
+          scenario = Scenario::FilteredScenario.new(filter)
+          if scenario.steps.empty?
+            puts "No scenario matching #{humanized_filter}"
+            exit 1
+          else
+            run_scenario(scenario)
+          end
+        end
+
+        def filter
+          if label
+            { :label => label }
+          else
+            { :tags => tags || [:basic] }
+          end
+        end
+
+        def humanized_filter
+          if label
+            "label #{label_string(label)}"
+          else
+            "tags #{tags.map { |tag| tag_string(tag) }}"
+          end
         end
       end
     end

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -7,23 +7,32 @@ module ForemanMaintain
 
     attr_reader :steps
 
-    class ChecksScenario < Scenario
+    class FilteredScenario < Scenario
       manual_detection
-      attr_reader :filter_tags
+      attr_reader :filter_label, :filter_tags
 
-      def initialize(filter_tags)
-        @filter_tags = filter_tags
-        @steps = ForemanMaintain.available_checks(:tags => filter_tags)
+      def initialize(filter)
+        @filter_tags = filter[:tags]
+        @filter_label = filter[:label]
+        @steps = ForemanMaintain.available_checks(filter)
       end
 
       def description
-        "checks with tags #{tag_string(@filter_tags)}"
+        if @filter_label
+          "check with label [#{dashize(@filter_label)}]"
+        else
+          "checks with tags #{tag_string(@filter_tags)}"
+        end
       end
 
       private
 
       def tag_string(tags)
-        tags.map { |tag| "[#{tag}]" }.join(' ')
+        tags.map { |tag| dashize("[#{tag}]") }.join(' ')
+      end
+
+      def dashize(string)
+        string.to_s.tr('_', '-')
       end
     end
 

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -5,6 +5,7 @@ require 'foreman_maintain/cli'
 include CliAssertions
 module ForemanMaintain
   describe Cli::HealthCommand do
+    include CliAssertions
     let :command do
       %w(health)
     end
@@ -19,7 +20,7 @@ Parameters:
     [ARG] ...                     subcommand arguments
 
 Subcommands:
-    list-checks                   List the checks based on criteria
+    list                          List the checks based on criteria
     list-tags                     List the tags to use for filtering checks
     check                         Run the health checks against the system
 
@@ -30,7 +31,7 @@ OUTPUT
 
     describe 'list-checks' do
       let :command do
-        %w(health list-checks)
+        %w(health list)
       end
       it 'lists the defined checks' do
         assert_cmd <<OUTPUT
@@ -57,12 +58,21 @@ OUTPUT
         %w(health check)
       end
 
-      it 'runs the checks' do
+      it 'runs the checks by label' do
+        Cli::HealthCommand.any_instance.expects(:run_scenario).with do |scenario|
+          scenario.filter_label.must_equal :present_service_is_running
+        end
+        run_cmd(['--label=present-service-is-running'])
+      end
+
+      it 'runs the default checks' do
         Cli::HealthCommand.any_instance.expects(:run_scenario).with do |scenario|
           scenario.filter_tags.must_equal [:basic]
         end
         run_cmd
-        Cli::HealthCommand.any_instance.unstub(:run_scenario)
+      end
+
+      it 'runs the checks by tags' do
         Cli::HealthCommand.any_instance.expects(:run_scenario).with do |scenario|
           scenario.filter_tags.must_equal [:pre_upgrade_check]
         end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 require 'foreman_maintain/cli'
 
 module ForemanMaintain
-  include CliAssertions
-
   describe Cli::MainCommand do
+    include CliAssertions
+
     let :command do
       []
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,8 @@ module CliAssertions
     capture_io do
       ForemanMaintain::Cli::MainCommand.run('foreman-maintain', command + args)
     end
+  rescue SystemExit # rubocop:disable Lint/HandleExceptions
+    # don't accept system exit from running a command
   end
 
   def simulate_carriage_returns(output)


### PR DESCRIPTION
This allows to run a specific check. It's useful for ad-hoc checks running, either for development
or instructing the users by support.