### PR TITLE
Better args handling

### DIFF
--- a/lib/foreman_maintain/cli/base.rb
+++ b/lib/foreman_maintain/cli/base.rb
@@ -41,6 +41,7 @@ module ForemanMaintain
         option '--label', 'label',
                'Limit only for a specific label. ' \
                  '(Use "list" command to see available labels)' do |label|
+          raise ArgumentError, 'value not specified' if label.nil? || label.empty?
           underscorize(label).to_sym
         end
       end
@@ -49,6 +50,7 @@ module ForemanMaintain
         option '--tags', 'tags',
                'Limit only for specific set of labels. ' \
                  '(Use list-tags command to see available tags)' do |tags|
+          raise ArgumentError, 'value not specified' if tags.nil? || tags.empty?
           tags.split(',').map(&:strip).map { |tag| underscorize(tag).to_sym }
         end
       end

--- a/lib/foreman_maintain/cli/health_command.rb
+++ b/lib/foreman_maintain/cli/health_command.rb
@@ -51,9 +51,9 @@ module ForemanMaintain
 
         def humanized_filter
           if label
-            "label #{label_string(label)}"
+            "label #{label_string(filter[:label])}"
           else
-            "tags #{tags.map { |tag| tag_string(tag) }}"
+            "tags #{filter[:tags].map { |tag| tag_string(tag) }.join}"
           end
         end
       end


### PR DESCRIPTION
Running args with emtpy arguments was faliing, example:

```
bin/foreman-maintain health check --tags
/home/inecas/Projects/ws/foreman-maintain/foreman_maintain/lib/foreman_maintain/cli/base.rb:42:in `block in tags_option': undefined method `split' for nil:NilClass (NoMethodError)
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/attribute/declaration.rb:35:in `instance_exec'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/attribute/declaration.rb:35:in `block in define_simple_writer_for'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/attribute/instance.rb:59:in `take'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/option/parsing.rb:39:in `set_options_from_command_line'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/option/parsing.rb:9:in `parse_options'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/command.rb:48:in `parse'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/command.rb:62:in `run'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/subcommand/execution.rb:11:in `execute'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/command.rb:63:in `run'
        from /home/inecas/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/clamp-1.1.2/lib/clamp/command.rb:132:in `run'
```

I blieve the right behaviour should be raising an error, when the tags value is not specified correctly.
The behaviour after the change is:

```
foreman-maintain health check --tags
ERROR: option '--tags': value not specified

See: 'foreman-maintain health check --help'
```

Also, running `health check` that should run just basic tags was not working correctly. The right behaviour is `basic` tags being used for this purpose