### PR TITLE
Code usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,14 +89,11 @@ class Checks::ForemanIsRuning < ForemanMaintain::Check
 
   def run
     # we are using methods of a feature.
+    # we can define additional steps to be executed as a follow-up
+    # of assertion failure
     assert(feature(:foreman).running?
-           'There are currently paused tasks in the system')
-  end
-
-  # we can define additional steps to be executed after this check is finished
-  # based on the result
-  def next_steps
-    [procedure(Procedures::ForemanStart)] if fail?
+           'There are currently paused tasks in the system'),
+           :next_steps => Procedures::ForemanStart.new)
   end
 end
 ```

--- a/README.md
+++ b/README.md
@@ -104,6 +104,23 @@ Similarly as features, also checks (and in fact all definitions) can used
 Every definition has a `label` (if not stated explicitly, it's
 determined from the class name).
 
+In case some operation take more time, it's possible to enable a spinner
+and update the spinner continuously with `with_spinner` method.
+
+```ruby
+def run
+  with_spinner do |spinner|
+    spinner.update 'checking foreman is running'
+    if feature(:foreman).running?
+      spinner.update 'foreman is not started, starting'
+      feature(:foreman).start
+    else
+      spinner.update 'foreman is started, restarting'
+    end
+  end
+end
+```
+
 ### Procedures
 
 Procedure defines some operation that can be performed against the system.

--- a/definitions/checks/disk_speed_minimal.rb
+++ b/definitions/checks/disk_speed_minimal.rb
@@ -1,15 +1,17 @@
 class Checks::DiskSpeedMinimal < ForemanMaintain::Check
+  metadata do
+    label :disk_io
+    description 'Check for recommended disk speed of pulp, mongodb, pgsql dir.'
+    tags :basic
+
+    confine do
+      execute?('which hdparm') && execute?('which fio')
+    end
+  end
+
   EXPECTED_IO = 80
   DEFAULT_UNIT   = 'MB/sec'.freeze
   DEFAULT_DIRS   = ['/var/lib/pulp', '/var/lib/mongodb', '/var/lib/pgsql'].freeze
-
-  label :disk_io
-  description 'Check for recommended disk speed of pulp, mongodb, pgsql dir.'
-  tags :basic
-
-  confine do
-    execute?('which hdparm') && execute?('which fio')
-  end
 
   def run
     success = true

--- a/definitions/checks/foreman_tasks_not_paused.rb
+++ b/definitions/checks/foreman_tasks_not_paused.rb
@@ -6,11 +6,9 @@ class Checks::ForemanTasksNotPaused < ForemanMaintain::Check
   end
 
   def run
-    assert(feature(:foreman_tasks).paused_tasks_count == 0,
-           'There are currently paused tasks in the system')
-  end
-
-  def next_steps
-    [procedure(Procedures::ForemanTasksResume)] if fail?
+    paused_tasks_count = feature(:foreman_tasks).paused_tasks_count
+    assert(paused_tasks_count == 0,
+           "There are currently #{paused_tasks_count} paused tasks in the system",
+           :next_steps => Procedures::ForemanTasksResume.new)
   end
 end

--- a/definitions/checks/foreman_tasks_not_paused.rb
+++ b/definitions/checks/foreman_tasks_not_paused.rb
@@ -1,7 +1,9 @@
 class Checks::ForemanTasksNotPaused < ForemanMaintain::Check
-  for_feature :foreman_tasks
-  description 'check for paused tasks'
-  tags :basic
+  metadata do
+    for_feature :foreman_tasks
+    description 'check for paused tasks'
+    tags :basic
+  end
 
   def run
     assert(feature(:foreman_tasks).paused_tasks_count == 0,

--- a/definitions/checks/foreman_tasks_not_running.rb
+++ b/definitions/checks/foreman_tasks_not_running.rb
@@ -1,7 +1,9 @@
 class Checks::ForemanTasksNotRunning < ForemanMaintain::Check
-  for_feature :foreman_tasks
-  description 'check for running tasks'
-  tags :pre_upgrade
+  metadata do
+    for_feature :foreman_tasks
+    description 'check for running tasks'
+    tags :pre_upgrade
+  end
 
   def run
     assert(feature(:foreman_tasks).running_tasks_count == 0,

--- a/definitions/features/downstream.rb
+++ b/definitions/features/downstream.rb
@@ -1,8 +1,10 @@
 class Features::Downstream < ForemanMaintain::Feature
-  label :downstream
+  metadata do
+    label :downstream
 
-  confine do
-    downstream_installation?
+    confine do
+      downstream_installation?
+    end
   end
 
   def current_version

--- a/definitions/features/foreman_1_11_x.rb
+++ b/definitions/features/foreman_1_11_x.rb
@@ -1,7 +1,9 @@
 require 'features/foreman_1_7_x'
 
 class Features::Foreman_1_11_x < Features::Foreman_1_7_x
-  confine do
-    check_min_version('foreman', '1.11')
+  metadata do
+    confine do
+      check_min_version('foreman', '1.11')
+    end
   end
 end

--- a/definitions/features/foreman_1_7_x.rb
+++ b/definitions/features/foreman_1_7_x.rb
@@ -1,7 +1,9 @@
 class Features::Foreman_1_7_x < ForemanMaintain::Feature
-  label :foreman
+  metadata do
+    label :foreman
 
-  confine do
-    check_min_version('foreman', '1.7')
+    confine do
+      check_min_version('foreman', '1.7')
+    end
   end
 end

--- a/definitions/features/foreman_database.rb
+++ b/definitions/features/foreman_database.rb
@@ -1,8 +1,10 @@
 class Features::ForemanDatabase < ForemanMaintain::Feature
-  label :foreman_database
+  metadata do
+    label :foreman_database
 
-  confine do
-    File.exist?('/etc/foreman/database.yml')
+    confine do
+      File.exist?('/etc/foreman/database.yml')
+    end
   end
 
   def query(sql)

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -1,9 +1,11 @@
 class Features::ForemanTasks < ForemanMaintain::Feature
-  label :foreman_tasks
+  metadata do
+    label :foreman_tasks
 
-  confine do
-    check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
-      check_min_version('tfm-rubygem-foreman-tasks', '0.7')
+    confine do
+      check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
+        check_min_version('tfm-rubygem-foreman-tasks', '0.7')
+    end
   end
 
   def running_tasks_count

--- a/definitions/features/upstream.rb
+++ b/definitions/features/upstream.rb
@@ -1,7 +1,9 @@
 class Features::Upstream < ForemanMaintain::Feature
-  label :upstream
+  metadata do
+    label :upstream
 
-  confine do
-    !downstream_installation?
+    confine do
+      !downstream_installation?
+    end
   end
 end

--- a/definitions/procedures/foreman_tasks_resume.rb
+++ b/definitions/procedures/foreman_tasks_resume.rb
@@ -1,6 +1,8 @@
 class Procedures::ForemanTasksResume < ForemanMaintain::Procedure
-  for_feature :foreman_tasks
-  description 'resume paused tasks'
+  metadata do
+    for_feature :foreman_tasks
+    description 'resume paused tasks'
+  end
 
   def run
     say 'resuming paused tasks'

--- a/definitions/procedures/foreman_tasks_resume.rb
+++ b/definitions/procedures/foreman_tasks_resume.rb
@@ -5,11 +5,13 @@ class Procedures::ForemanTasksResume < ForemanMaintain::Procedure
   end
 
   def run
-    say 'resuming paused tasks'
-    sleep 1
-    say 'hold on'
-    sleep 1
-    say 'almost there'
-    sleep 1
+    with_spinner('resuming paused tasks') do |spinner|
+      sleep 1
+      spinner.update 'hold on'
+      sleep 1
+      spinner.update 'almost there'
+      sleep 1
+      spinner.update 'finished'
+    end
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
+++ b/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
@@ -7,8 +7,7 @@ class Scenarios::PreUpgradeCheckForeman_1_14 < ForemanMaintain::Scenario
     end
   end
 
-
   def compose
-    steps.concat(find_checks(:basic))
+    add_steps(find_checks(:basic))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
+++ b/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
@@ -1,10 +1,12 @@
 class Scenarios::PreUpgradeCheckForeman_1_14 < ForemanMaintain::Scenario
-  description 'checks before upgrading to Foreman 1.14'
-  confine do
-    feature(:upstream)
+  metadata do
+    description 'checks before upgrading to Foreman 1.14'
+    tags :pre_upgrade_check
+    confine do
+      feature(:upstream)
+    end
   end
 
-  tags :pre_upgrade_check
 
   def compose
     steps.concat(find_checks(:basic))

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_0_z < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_0_z < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_0_z
-  description 'checks before upgrading to Satellite 6.0'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.0.')
+  metadata do
+    tags :pre_upgrade_check, :satellite_6_0_z
+    description 'checks before upgrading to Satellite 6.0'
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.0.')
+    end
   end
 
   def compose

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_1 < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_1
-  description 'checks before upgrading to Satellite 6.1'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.0.')
+  metadata do
+    description 'checks before upgrading to Satellite 6.1'
+    tags :pre_upgrade_check, :satellite_6_1
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.0.')
+    end
   end
 
   def compose

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_1 < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_1_z < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_1_z
-  description 'checks before upgrading to Satellite 6.1.z'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.1.')
+  metadata do
+    description 'checks before upgrading to Satellite 6.1.z'
+    tags :pre_upgrade_check, :satellite_6_1_z
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.1.')
+    end
   end
 
   def compose

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_1_z < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_2 < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_2
-  description 'checks before upgrading to Satellite 6.2'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.1.')
+  metadata do
+    description 'checks before upgrading to Satellite 6.2'
+    tags :pre_upgrade_check, :satellite_6_2
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.1.')
+    end
   end
 
   def compose

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_2 < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_2_z < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_2_z < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_2_z
-  description 'checks before upgrading to Satellite 6.2.z'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.2.')
+  metadata do
+    description 'checks before upgrading to Satellite 6.2.z'
+    tags :pre_upgrade_check, :satellite_6_2_z
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.2.')
+    end
   end
 
   def compose

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_3 < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps.concat(find_checks(:pre_upgrade))
+    add_steps(find_checks(:basic))
+    add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
@@ -1,8 +1,10 @@
 class Scenarios::PreUpgradeCheckSatellite_6_3 < ForemanMaintain::Scenario
-  tags :pre_upgrade_check, :satellite_6_3
-  description 'checks before upgrading to Satellite 6.3'
-  confine do
-    feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.2.')
+  metadata do
+    description 'checks before upgrading to Satellite 6.3'
+    tags :pre_upgrade_check, :satellite_6_3
+    confine do
+      feature(:downstream) && feature(:downstream).current_version.to_s.start_with?('6.2.')
+    end
   end
 
   def compose

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -2,6 +2,7 @@ if RUBY_VERSION <= '1.8.7'
   require 'rubygems'
 end
 
+require 'forwardable'
 require 'json'
 
 module ForemanMaintain

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -6,9 +6,9 @@ require 'json'
 
 module ForemanMaintain
   require 'foreman_maintain/concerns/logger'
+  require 'foreman_maintain/concerns/finders'
   require 'foreman_maintain/concerns/metadata'
   require 'foreman_maintain/concerns/system_helpers'
-  require 'foreman_maintain/concerns/finders'
   require 'foreman_maintain/top_level_modules'
   require 'foreman_maintain/config'
   require 'foreman_maintain/detector'

--- a/lib/foreman_maintain/check.rb
+++ b/lib/foreman_maintain/check.rb
@@ -10,10 +10,6 @@ module ForemanMaintain
     class Fail < StandardError
     end
 
-    def initialize(associated_feature)
-      @associated_feature = associated_feature
-    end
-
     def assert(condition, error_message)
       raise Fail, error_message unless condition
     end

--- a/lib/foreman_maintain/check.rb
+++ b/lib/foreman_maintain/check.rb
@@ -10,8 +10,23 @@ module ForemanMaintain
     class Fail < StandardError
     end
 
-    def assert(condition, error_message)
-      raise Fail, error_message unless condition
+    # run condition and mark the check as failed when not passing
+    #
+    # ==== Options
+    #
+    # * +:next_steps* - one or more procedures that can be followed to address
+    #                   the failure, will be offered to the user when running
+    #                   in interactive mode
+    def assert(condition, error_message, options = {})
+      unexpected_options = options.keys - [:next_steps]
+      unless unexpected_options.empty?
+        raise ArgumentError, "Unexpected options #{unexpected_options.inspect}"
+      end
+      unless condition
+        next_steps = Array(options.fetch(:next_steps, []))
+        self.next_steps.concat(next_steps)
+        raise Fail, error_message
+      end
     end
 
     # public method to be overriden

--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -2,8 +2,11 @@ module ForemanMaintain
   class Executable
     attr_accessor :associated_feature
 
-    def initialize(associated_feature)
-      @associated_feature = associated_feature
+    def associated_feature
+      return @associated_feature if defined? @associated_feature
+      if metadata[:for_feature]
+        @associated_feature = feature(metadata[:for_feature])
+      end
     end
 
     # public method to be overriden
@@ -39,6 +42,18 @@ module ForemanMaintain
     def __run__(execution)
       @_execution = execution
       run
+    end
+
+    # method defined both on object and class to ensure we work always with object
+    # even when the definitions provide us only class
+    def ensure_instance
+      self
+    end
+
+    class << self
+      def ensure_instance
+        new
+      end
     end
   end
 end

--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -1,5 +1,8 @@
 module ForemanMaintain
   class Executable
+    extend Forwardable
+    def_delegators :execution, :success?, :fail?
+    def_delegators :execution, :puts, :print, :with_spinner
     attr_accessor :associated_feature
 
     def associated_feature
@@ -28,17 +31,9 @@ module ForemanMaintain
       end
     end
 
-    def success?
-      execution.success?
-    end
-
-    def fail?
-      execution.fail?
-    end
-
     # update reporter about the current message
     def say(message)
-      @_execution.update(message)
+      execution.update(message)
     end
 
     # internal method called by executor

--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -14,8 +14,11 @@ module ForemanMaintain
       raise NotImplementedError
     end
 
-    # override to offer steps to be executed after this one
-    def next_steps; end
+    # next steps to be offered to the user after the step is run
+    # It can be added for example from the assert method
+    def next_steps
+      @next_steps ||= []
+    end
 
     def execution
       if @_execution

--- a/lib/foreman_maintain/reporter.rb
+++ b/lib/foreman_maintain/reporter.rb
@@ -1,5 +1,10 @@
 module ForemanMaintain
   class Reporter
+    class DummySpinner
+      def update(_message)
+        # do nothing
+      end
+    end
     require 'foreman_maintain/reporter/cli_reporter'
 
     # Each public method is a hook called by executor at the specific point
@@ -7,12 +12,18 @@ module ForemanMaintain
 
     def before_execution_starts(_execution); end
 
-    def on_execution_update(_execution, _update); end
-
     def after_execution_finishes(_execution); end
 
     def after_scenario_finishes(_scenario); end
 
     def on_next_steps_offer(_runner, _steps); end
+
+    def with_spinner(_message, &_block)
+      yield DummySpinner.new
+    end
+
+    def print(_message); end
+
+    def puts(_message); end
   end
 end

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -33,7 +33,10 @@ module ForemanMaintain
     private
 
     def ask_about_offered_steps(steps)
-      @reporter.on_next_steps(self, steps) if steps
+      if steps
+        steps = steps.map(&:ensure_instance)
+        @reporter.on_next_steps(self, steps)
+      end
     end
   end
 end

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -33,7 +33,7 @@ module ForemanMaintain
     private
 
     def ask_about_offered_steps(steps)
-      if steps
+      if steps && !steps.empty?
         steps = steps.map(&:ensure_instance)
         @reporter.on_next_steps(self, steps)
       end

--- a/lib/foreman_maintain/runner/execution.rb
+++ b/lib/foreman_maintain/runner/execution.rb
@@ -3,6 +3,8 @@ module ForemanMaintain
     # Class representing an execution of a single step in scenario
     class Execution
       include Concerns::Logger
+      extend Forwardable
+      def_delegators :@reporter, :with_spinner, :puts, :print
 
       # Step performed as part of the execution
       attr_reader :step

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -8,7 +8,9 @@ module ForemanMaintain
     attr_reader :steps
 
     class FilteredScenario < Scenario
-      manual_detection
+      metadata do
+        manual_detection
+      end
       attr_reader :filter_label, :filter_tags
 
       def initialize(filter)

--- a/lib/foreman_maintain/scenario.rb
+++ b/lib/foreman_maintain/scenario.rb
@@ -11,12 +11,13 @@ module ForemanMaintain
       metadata do
         manual_detection
       end
+
       attr_reader :filter_label, :filter_tags
 
       def initialize(filter)
         @filter_tags = filter[:tags]
         @filter_label = filter[:label]
-        @steps = ForemanMaintain.available_checks(filter)
+        @steps = ForemanMaintain.available_checks(filter).map(&:ensure_instance)
       end
 
       def description
@@ -45,6 +46,16 @@ module ForemanMaintain
 
     # Override to compose steps for the scenario
     def compose; end
+
+    def add_steps(steps)
+      steps.each do |step|
+        self.steps << step.ensure_instance
+      end
+    end
+
+    def add_step(step)
+      add_steps([step])
+    end
 
     def self.inspect
       "Scenario Class #{metadata[:description]}<#{name}>"

--- a/test/definitions/checks/disk_speed_minimal_test.rb
+++ b/test/definitions/checks/disk_speed_minimal_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 describe Checks::DiskSpeedMinimal do
   include DefinitionsTestHelper
 
-  let(:check_disk_io) { described_class.new(nil) }
+  let(:check_disk_io) { described_class.new }
 
   it 'should confine existence of hdparm and fio' do
     described_class.stubs(:execute?).with('which hdparm').returns(true)

--- a/test/definitions/scenarios/upgrade_satellite_6_2_test.rb
+++ b/test/definitions/scenarios/upgrade_satellite_6_2_test.rb
@@ -6,7 +6,7 @@ module Scenarios
 
     before do
       assume_feature_present(:downstream) do |feature|
-        feature.stubs(:current_version => version('6.1.8'))
+        feature.any_instance.stubs(:current_version => version('6.1.8'))
       end
       assume_feature_present(:foreman_tasks)
     end
@@ -18,14 +18,14 @@ module Scenarios
     it 'is valid only for 6.1.x versions' do
       assert_scenario(:tags => [:pre_upgrade_check, :satellite_6_2])
 
-      assume_feature_present(:downstream) do |feature|
-        feature.stubs(:current_version => version('6.0.8'))
+      assume_feature_present(:downstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('6.0.8'))
       end
       detector.refresh
       refute_scenario(:tags => [:pre_upgrade_check, :satellite_6_2])
 
-      assume_feature_present(:downstream) do |feature|
-        feature.stubs(:current_version => version('6.2.1'))
+      assume_feature_present(:downstream) do |feature_class|
+        feature_class.any_instance.stubs(:current_version => version('6.2.1'))
       end
       detector.refresh
       refute_scenario(:tags => [:pre_upgrade_check, :satellite_6_2])
@@ -36,8 +36,8 @@ module Scenarios
     end
 
     it 'composes the pre upgrade checks for migration from satellite 6.1.x to 6.2' do
-      assert_includes scenario.steps, check(:foreman_tasks_not_paused)
-      assert_includes scenario.steps, check(:foreman_tasks_not_running)
+      assert(scenario.steps.find { |step| step.is_a? Checks::ForemanTasksNotPaused })
+      assert(scenario.steps.find { |step| step.is_a? Checks::ForemanTasksNotRunning })
     end
   end
 end

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -7,23 +7,21 @@ module DefinitionsTestHelper
     @detector ||= ForemanMaintain.detector
   end
 
-  def load_feature(feature_label)
-    feature = detector.send(:autodetect_features)[feature_label.to_sym].first
-    raise "Feature #{feature_label} not present in autodetect features" unless feature
-    yield feature
+  def feature_class(feature_label)
+    feature_class = detector.send(:autodetect_features)[feature_label.to_sym].first
+    raise "Feature #{feature_label} not present in autodetect features" unless feature_class
+    feature_class
   end
 
   def assume_feature_present(feature_label)
-    load_feature(feature_label) do |feature|
-      feature.stubs(:present? => true)
-      yield feature if block_given?
-    end
+    feature_class = self.feature_class(feature_label)
+    feature_class.stubs(:present? => true)
+    yield feature_class if block_given?
   end
 
   def assume_feature_absent(feature_label)
-    load_feature(feature_label) do |feature|
-      feature.stubs(:present? => false)
-      yield feature if block_given?
+    feature_class(feature_label) do |feature_class|
+      feature_class.stubs(:present? => false)
     end
   end
 
@@ -43,7 +41,7 @@ module DefinitionsTestHelper
   # assume_feature_absent), assert the scenario with given filter is considered
   # present
   def assert_scenario(filter)
-    scenario = find_scenarios(:tags => [:pre_upgrade_check, :satellite_6_2]).first
+    scenario = find_scenarios(filter).first
     assert scenario, "Expected the scenario #{filter} to be present"
     scenario
   end

--- a/test/lib/detector_test.rb
+++ b/test/lib/detector_test.rb
@@ -28,25 +28,25 @@ module ForemanMaintain
              'failed to detect feature that reference another feature in `confine` block'
     end
 
-    it 'allows to filter checks based on label or class' do
+    it 'allows to filter checks based on label or class ===' do
       checks = detector.available_checks(:label => :present_service_is_running)
       assert_equal(1, checks.size,
                    'expected exactly one check to be found')
-      assert(checks.find { |c| c.is_a? Checks::PresentServiceIsRunning },
-             'checks that should be found is missing')
+      assert_includes(checks, Checks::PresentServiceIsRunning,
+                      'checks that should be found is missing')
       checks = detector.available_checks(:class => Checks::PresentServiceIsRunning)
       assert_equal(1, checks.size,
                    'expected exactly one check to be found')
-      assert(checks.find { |c| c.is_a? Checks::PresentServiceIsRunning },
-             'checks that should be found is missing')
+      assert_includes(checks, Checks::PresentServiceIsRunning,
+                      'checks that should be found is missing')
     end
 
     it 'allows to filter checks based on metadata and present features' do
       checks = detector.available_checks(:basic)
-      assert(checks.find { |c| c.is_a? Checks::PresentServiceIsRunning },
-             'checks that should be found is missing')
-      refute(checks.find { |c| c.is_a? Checks::MissingServiceIsRunning },
-             'checks that should not be found are present')
+      assert_includes(checks, Checks::PresentServiceIsRunning,
+                      'checks that should be found is missing')
+      refute_includes(checks, Checks::MissingServiceIsRunning,
+                      'checks that should not be found are present')
     end
 
     it 'allows to filter scenarios based on metadata and present features' do

--- a/test/lib/reporter_test.rb
+++ b/test/lib/reporter_test.rb
@@ -20,7 +20,7 @@ module ForemanMaintain
       Scenarios::PresentUpgrade.new
     end
 
-    it 'reports human-readmable info about the run' do
+    it 'reports human-readable info about the run' do
       reporter.before_scenario_starts(scenario)
 
       step = Checks::PresentServiceIsRunning.new
@@ -40,10 +40,10 @@ module ForemanMaintain
       assert_equal <<STR, captured_out
 Running present_service upgrade scenario
 --------------------------------------------------------------------------------
-| present service run check:                                        [OK]       |
+present service run check:                                            [OK]
 --------------------------------------------------------------------------------
-| present service run check:                                        [FAIL]     |
-| The service is not running                                                   |
+present service run check:                                            [FAIL]
+The service is not running
 --------------------------------------------------------------------------------
 STR
     end

--- a/test/lib/reporter_test.rb
+++ b/test/lib/reporter_test.rb
@@ -23,7 +23,7 @@ module ForemanMaintain
     it 'reports human-readmable info about the run' do
       reporter.before_scenario_starts(scenario)
 
-      step = Checks::PresentServiceIsRunning.new(nil)
+      step = Checks::PresentServiceIsRunning.new
       execution = Runner::Execution.new(step, reporter)
 
       reporter.before_execution_starts(execution)
@@ -51,8 +51,8 @@ STR
     it 'asks about the next steps' do
       runner_mock = MiniTest::Mock.new
       will_press('y')
-      start_step = Procedures::PresentServiceStart.new(nil)
-      restart_step = Procedures::PresentServiceRestart.new(nil)
+      start_step = Procedures::PresentServiceStart.new
+      restart_step = Procedures::PresentServiceRestart.new
       runner_mock.expect(:add_step, nil, [start_step])
       reporter.on_next_steps(runner_mock, [start_step])
       assert_equal 'Continue with step [start the present service]?, [yN]',

--- a/test/lib/runner_test.rb
+++ b/test/lib/runner_test.rb
@@ -16,8 +16,7 @@ module ForemanMaintain
 
     it 'performs all steps in the scenario' do
       runner.run
-      assert_equal(reporter.log,
-                   [['before_scenario_starts', 'present_service upgrade scenario'],
+      assert_equal([['before_scenario_starts', 'present_service upgrade scenario'],
                     ['before_execution_starts', 'present service run check'],
                     ['after_execution_finishes', 'present service run check'],
                     ['on_next_steps', 'start the present service'],
@@ -26,6 +25,7 @@ module ForemanMaintain
                     ['before_execution_starts', 'restart present service'],
                     ['after_execution_finishes', 'restart present service'],
                     ['after_scenario_finishes', 'present_service upgrade scenario']],
+                   reporter.log,
                    'unexpected order of execution')
     end
   end

--- a/test/lib/support/additional_definitions/features/present_service_2.rb
+++ b/test/lib/support/additional_definitions/features/present_service_2.rb
@@ -1,8 +1,10 @@
 require 'features/present_service'
 class Features::PresentService2 < Features::PresentService
-  label :my_test_feature
+  metadata do
+    label :my_test_feature
 
-  confine do
-    TestHelper.use_present_service_2
+    confine do
+      TestHelper.use_present_service_2
+    end
   end
 end

--- a/test/lib/support/definitions/checks/external_service_is_accessible.rb
+++ b/test/lib/support/definitions/checks/external_service_is_accessible.rb
@@ -1,6 +1,8 @@
 class Checks::ExternalServiceIsAccessible < ForemanMaintain::Check
-  tags :pre_upgrade_check
-  description 'external_service_is_accessible'
+  metadata do
+    tags :pre_upgrade_check
+    description 'external_service_is_accessible'
+  end
 
   def run; end
 end

--- a/test/lib/support/definitions/checks/missing_service_is_running.rb
+++ b/test/lib/support/definitions/checks/missing_service_is_running.rb
@@ -1,8 +1,10 @@
 class Checks::MissingServiceIsRunning < ForemanMaintain::Check
-  # simulate a check defined for service that is not present on the system
-  for_feature(:missing_service)
-  tags :basic
-  description 'missing service is running check'
+  metadata do
+    # simulate a check defined for service that is not present on the system
+    for_feature(:missing_service)
+    tags :basic
+    description 'missing service is running check'
+  end
 
   def run
     assert(feature(:missing_service).running?,

--- a/test/lib/support/definitions/checks/present_service_is_running.rb
+++ b/test/lib/support/definitions/checks/present_service_is_running.rb
@@ -1,8 +1,10 @@
 class Checks::PresentServiceIsRunning < ForemanMaintain::Check
-  label :present_service_is_running
-  for_feature(:present_service)
-  tags :basic
-  description 'present service run check'
+  metadata do
+    label :present_service_is_running
+    for_feature(:present_service)
+    tags :basic
+    description 'present service run check'
+  end
 
   def run
     assert(feature(:present_service).running?,

--- a/test/lib/support/definitions/checks/present_service_is_running.rb
+++ b/test/lib/support/definitions/checks/present_service_is_running.rb
@@ -8,10 +8,7 @@ class Checks::PresentServiceIsRunning < ForemanMaintain::Check
 
   def run
     assert(feature(:present_service).running?,
-           'present service is not running')
-  end
-
-  def next_steps
-    [procedure(Procedures::PresentServiceStart)] if fail?
+           'present service is not running',
+           :next_steps => Procedures::PresentServiceStart.new)
   end
 end

--- a/test/lib/support/definitions/features/cilent.rb
+++ b/test/lib/support/definitions/features/cilent.rb
@@ -1,8 +1,10 @@
 class Features::Client < ForemanMaintain::Feature
-  label :client
+  metadata do
+    label :client
 
-  confine do
-    # if server is not present, we assume it's client
-    !feature(:server)
+    confine do
+      # if server is not present, we assume it's client
+      !feature(:server)
+    end
   end
 end

--- a/test/lib/support/definitions/features/missing_service.rb
+++ b/test/lib/support/definitions/features/missing_service.rb
@@ -1,9 +1,11 @@
 class Features::MissingService < ForemanMaintain::Feature
-  label :missing_service
+  metadata do
+    label :missing_service
 
-  confine do
-    # simulate this service is not present on the system
-    false
+    confine do
+      # simulate this service is not present on the system
+      false
+    end
   end
 
   def restart

--- a/test/lib/support/definitions/features/present_service.rb
+++ b/test/lib/support/definitions/features/present_service.rb
@@ -14,4 +14,8 @@ class Features::PresentService < ForemanMaintain::Feature
   def restart
     # pretend we restart the service
   end
+
+  def running?
+    false
+  end
 end

--- a/test/lib/support/definitions/features/present_service.rb
+++ b/test/lib/support/definitions/features/present_service.rb
@@ -1,8 +1,10 @@
 class Features::PresentService < ForemanMaintain::Feature
-  label :present_service
+  metadata do
+    label :present_service
 
-  confine do
-    0.zero?
+    confine do
+      0.zero?
+    end
   end
 
   def start

--- a/test/lib/support/definitions/features/server.rb
+++ b/test/lib/support/definitions/features/server.rb
@@ -1,8 +1,10 @@
 class Features::Server < ForemanMaintain::Feature
-  label :server
+  metadata do
+    label :server
 
-  confine do
-    true
+    confine do
+      true
+    end
   end
 
   def additional_features

--- a/test/lib/support/definitions/features/sub_service.rb
+++ b/test/lib/support/definitions/features/sub_service.rb
@@ -1,7 +1,9 @@
 module Features
   class SubService < ForemanMaintain::Feature
-    label :sub_service
-    manual_detection
+    metadata do
+      label :sub_service
+      manual_detection
+    end
 
     def initialize(sub_service_name)
       @sub_serivce_name = sub_service_name

--- a/test/lib/support/definitions/procedures/missing_service_restart.rb
+++ b/test/lib/support/definitions/procedures/missing_service_restart.rb
@@ -1,7 +1,9 @@
 class Procedures::MissingServiceRestart < ForemanMaintain::Procedure
-  for_feature(:missing_service)
-  tags :basic
-  description 'restart missing service'
+  metadata do
+    for_feature(:missing_service)
+    tags :basic
+    description 'restart missing service'
+  end
 
   def run
     feature(:missing_service).restart

--- a/test/lib/support/definitions/procedures/present_service_restart.rb
+++ b/test/lib/support/definitions/procedures/present_service_restart.rb
@@ -1,8 +1,10 @@
 class Procedures::PresentServiceRestart < ForemanMaintain::Procedure
-  for_feature(:present_service)
-  label :present_service_restart
-  tags :restart
-  description 'restart present service'
+  metadata do
+    for_feature(:present_service)
+    label :present_service_restart
+    tags :restart
+    description 'restart present service'
+  end
 
   def run
     feature(:present_service).restart

--- a/test/lib/support/definitions/procedures/present_service_start.rb
+++ b/test/lib/support/definitions/procedures/present_service_start.rb
@@ -1,7 +1,9 @@
 class Procedures::PresentServiceStart < ForemanMaintain::Procedure
-  for_feature(:present_service)
-  tags :start
-  description 'start the present service'
+  metadata do
+    for_feature(:present_service)
+    tags :start
+    description 'start the present service'
+  end
 
   def run
     feature(:present_service).start

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -1,11 +1,11 @@
 class Scenarios::MissingUpgrade < ForemanMaintain::Scenario
-  confine do
-    feature(:missing_service)
+  metadata do
+    tags :upgrade, :missing_upgrade
+    description 'missing_service upgrade scenario'
+    confine do
+      feature(:missing_service)
+    end
   end
-
-  tags :upgrade, :missing_upgrade
-
-  description 'missing_service upgrade scenario'
 
   def compose
     steps.concat(find_checks(:basic))

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -8,6 +8,6 @@ class Scenarios::MissingUpgrade < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
+    add_steps(find_checks(:basic))
   end
 end

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -1,11 +1,12 @@
 class Scenarios::PresentUpgrade < ForemanMaintain::Scenario
-  confine do
-    feature(:present_service)
+  metadata do
+    description 'present_service upgrade scenario'
+    tags :upgrade, :present_upgrade
+
+    confine do
+      feature(:present_service)
+    end
   end
-
-  tags :upgrade, :present_upgrade
-
-  description 'present_service upgrade scenario'
 
   def compose
     steps.concat(find_checks(:basic))

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -9,7 +9,7 @@ class Scenarios::PresentUpgrade < ForemanMaintain::Scenario
   end
 
   def compose
-    steps.concat(find_checks(:basic))
-    steps << procedure(Procedures::PresentServiceRestart)
+    add_steps(find_checks(:basic))
+    add_step(procedure(Procedures::PresentServiceRestart))
   end
 end


### PR DESCRIPTION
While trying to implement the tasks checks, I've hit several issues that were
complicating my life as an author of the check. This is a set of changes I've made
to make the life of others better as well.

**Extract metadata DSL to separate namespace**
The reason for this was to make the work with classes metadata a bit easier,
we could not use MyCheck.label before, becuse the label was already a method
of the DSL. It was needed to be able to do the detections on classes, not instances of the classes (see below)

**Run confine against classes, not objects**

This allows us to have multiple objects of the same procedure in the
system, differing in the constructor parameters. Useful for parametrized
procedures.

**Set next steps with the assert check**

This allows adding more assertions to the check, each adding their own
next steps.

**Make the spinner opt-in, not opt-out**

The default spinner caused issues when one needs to interact with the
user (printing additional messages). As it's needed only for long
running actions, it should not be enforced by default.