### PR TITLE
Fixes #19 - Handled sync plans before & after upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 Gemfile.lock
 log/
 config/foreman_maintain.yml
+data.yml

--- a/config/foreman_maintain.yml.example
+++ b/config/foreman_maintain.yml.example
@@ -7,3 +7,6 @@
 
 # Mention definitions directories. Default
 # :definitions_dirs:
+
+# Mention file path to store data
+# :storage_file: 'data.yml'

--- a/config/foreman_maintain.yml.test
+++ b/config/foreman_maintain.yml.test
@@ -9,3 +9,6 @@
 :definitions_dirs:
   - 'test/lib/support/definitions'
   - 'test/lib/support/additional_definitions'
+
+# Mention file path to store data
+:storage_file: 'test/data_test.yml'

--- a/definitions/checks/sync_plans/with_disabled_status.rb
+++ b/definitions/checks/sync_plans/with_disabled_status.rb
@@ -1,0 +1,16 @@
+module Checks::SyncPlans
+  class WithDisabledStatus < ForemanMaintain::Check
+    metadata do
+      for_feature :sync_plans
+      description 'check for disabled sync plans'
+      tags :post_upgrade
+    end
+
+    def run
+      disabled_plans_count = feature(:sync_plans).disabled_plans_count
+      assert(disabled_plans_count == 0,
+             "There are #{disabled_plans_count} disabled sync plans which needs to be enabled",
+             :next_steps => Procedures::SyncPlans::Enable.new)
+    end
+  end
+end

--- a/definitions/checks/sync_plans/with_enabled_status.rb
+++ b/definitions/checks/sync_plans/with_enabled_status.rb
@@ -1,0 +1,16 @@
+module Checks::SyncPlans
+  class WithEnabledStatus < ForemanMaintain::Check
+    metadata do
+      for_feature :sync_plans
+      description 'check for enabled sync plans'
+      tags :pre_upgrade
+    end
+
+    def run
+      active_sync_plans_count = feature(:sync_plans).active_sync_plans_count
+      assert(active_sync_plans_count == 0,
+             "There are total #{active_sync_plans_count} active sync plans in the system",
+             :next_steps => Procedures::SyncPlans::Disable.new)
+    end
+  end
+end

--- a/definitions/features/sync_plans.rb
+++ b/definitions/features/sync_plans.rb
@@ -1,0 +1,74 @@
+class Features::SyncPlans < ForemanMaintain::Feature
+  metadata do
+    label :sync_plans
+  end
+
+  def active_sync_plans_count
+    feature(:foreman_database).query(
+      <<-SQL
+        SELECT count(*) AS count FROM katello_sync_plans WHERE enabled ='t'
+      SQL
+    ).first['count'].to_i
+  end
+
+  def ids_by_status(enabled = true)
+    enabled = enabled ? 't' : 'f'
+    feature(:foreman_database).query(
+      <<-SQL
+        SELECT id FROM katello_sync_plans WHERE enabled ='#{enabled}'
+      SQL
+    ).map { |r| r['id'].to_i }
+  end
+
+  def disabled_plans_count
+    data[:disabled].length
+  end
+
+  def make_disable(ids)
+    update_records(ids, false)
+  end
+
+  def make_enable
+    update_records(data[:disabled], true)
+  end
+
+  private
+
+  def update_records(ids, enabled)
+    updated_record_ids = []
+    ids.each do |sp_id|
+      result = hammer("sync-plan update --id #{sp_id} --enabled #{enabled}")
+      if result.include?('Sync plan updated')
+        updated_record_ids << sp_id
+      else
+        raise result
+      end
+    end
+  ensure
+    new_data = sync_plan_data(enabled, updated_record_ids)
+    save_state(new_data)
+  end
+
+  def data
+    upgrade_storage = ForemanMaintain.storage(:upgrade)
+    @data ||= upgrade_storage.data.fetch(:sync_plans, :enabled => [], :disabled => [])
+    @data
+  end
+
+  def sync_plan_data(enabled, new_ids)
+    sync_plan_hash = data
+    if enabled
+      sync_plan_hash[:disabled] -= new_ids
+      sync_plan_hash[:enabled] = new_ids
+    else
+      sync_plan_hash[:disabled].concat(new_ids)
+    end
+    sync_plan_hash
+  end
+
+  def save_state(sync_plan_hash = {})
+    storage = ForemanMaintain.storage(:upgrade)
+    storage[:sync_plans] = sync_plan_hash
+    storage.save
+  end
+end

--- a/definitions/procedures/sync_plans/disable.rb
+++ b/definitions/procedures/sync_plans/disable.rb
@@ -1,0 +1,22 @@
+module Procedures::SyncPlans
+  class Disable < ForemanMaintain::Procedure
+    metadata do
+      for_feature :sync_plans
+      description 'disable active sync plans'
+    end
+
+    def run
+      disable_all_enabled_sync_plans
+    end
+
+    private
+
+    def disable_all_enabled_sync_plans
+      with_spinner('disabling sync plans') do |spinner|
+        ids = feature(:sync_plans).ids_by_status(true)
+        feature(:sync_plans).make_disable(ids)
+        spinner.update "Total #{ids.length} sync plans are now disabled."
+      end
+    end
+  end
+end

--- a/definitions/procedures/sync_plans/enable.rb
+++ b/definitions/procedures/sync_plans/enable.rb
@@ -1,0 +1,18 @@
+module Procedures::SyncPlans
+  class Enable < ForemanMaintain::Procedure
+    metadata do
+      for_feature :sync_plans
+      description 're-enable active sync plans'
+    end
+
+    def run
+      enabled_sync_plans
+    end
+
+    private
+
+    def enabled_sync_plans
+      feature(:sync_plans).make_enable
+    end
+  end
+end

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -15,6 +15,7 @@ module ForemanMaintain
   require 'foreman_maintain/concerns/system_helpers'
   require 'foreman_maintain/concerns/hammer'
   require 'foreman_maintain/top_level_modules'
+  require 'foreman_maintain/yaml_storage'
   require 'foreman_maintain/config'
   require 'foreman_maintain/detector'
   require 'foreman_maintain/feature'
@@ -106,6 +107,12 @@ module ForemanMaintain
       custom_configs
     rescue => e
       raise "Couldn't load configuration file. Error: #{e.message}"
+    end
+
+    def storage(label)
+      ForemanMaintain::YamlStorage.load(label)
+    rescue => e
+      logger.error "Invalid Storage label i.e #{label}. Error - #{e.message}"
     end
   end
 end

--- a/lib/foreman_maintain/config.rb
+++ b/lib/foreman_maintain/config.rb
@@ -1,7 +1,7 @@
 require 'fileutils'
 module ForemanMaintain
   class Config
-    attr_accessor :definitions_dirs, :log_level, :log_dir
+    attr_accessor :definitions_dirs, :log_level, :log_dir, :storage_file
 
     def initialize(options = {})
       @definitions_dirs = options.fetch(:definitions_dirs,
@@ -9,6 +9,7 @@ module ForemanMaintain
 
       @log_level = options.fetch(:log_level, ::Logger::DEBUG)
       @log_dir = find_log_dir_path(options.fetch(:log_dir, 'log'))
+      @storage_file = options.fetch(:storage_file, 'data.yml')
     end
 
     private

--- a/lib/foreman_maintain/feature.rb
+++ b/lib/foreman_maintain/feature.rb
@@ -4,6 +4,7 @@ module ForemanMaintain
     include Concerns::SystemHelpers
     include Concerns::Metadata
     include Concerns::Finders
+    include ForemanMaintain::Concerns::Hammer
 
     def self.inspect
       "Feature Class #{metadata[:label]}<#{name}>"

--- a/lib/foreman_maintain/yaml_storage.rb
+++ b/lib/foreman_maintain/yaml_storage.rb
@@ -1,0 +1,48 @@
+module ForemanMaintain
+  class YamlStorage
+    extend Forwardable
+    attr_reader :sub_key, :data
+    def_delegators :data, :[], :[]=
+
+    def initialize(sub_key, data = {})
+      @sub_key = sub_key
+      @data = data
+    end
+
+    def save
+      self.class.save_sub_key(sub_key, data)
+    end
+
+    class << self
+      def load_file
+        if File.exist?(storage_file_path)
+          YAML.load_file(storage_file_path) || {}
+        else
+          {}
+        end
+      end
+
+      def storage_file_path
+        File.expand_path(ForemanMaintain.config.storage_file)
+      end
+
+      def storage_register
+        @storage_register ||= {}
+      end
+
+      def load(sub_key)
+        storage_register[sub_key] ||= load_file.fetch(sub_key, {})
+        YamlStorage.new(sub_key, storage_register[sub_key])
+      end
+
+      def save_sub_key(sub_key, data_val)
+        new_data = load_file.merge(sub_key => data_val)
+        File.open(storage_file_path, 'w') { |f| f.write new_data.to_yaml }
+      end
+
+      def save_all
+        storage_register.values.each(&:save)
+      end
+    end
+  end
+end

--- a/test/definitions/checks/sync_plans/with_disabled_status_test.rb
+++ b/test/definitions/checks/sync_plans/with_disabled_status_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Checks::SyncPlans::WithDisabledStatus do
+  include DefinitionsTestHelper
+
+  subject do
+    Checks::SyncPlans::WithDisabledStatus.new
+  end
+
+  it 'passes when no sync plans which were disabled during pre-upgrade check' do
+    assume_feature_present(:sync_plans, :disabled_plans_count => 0)
+    result = run_check(subject)
+    assert result.success?
+  end
+
+  it 'fails when disabled sync plans are present' do
+    assume_feature_present(:sync_plans, :disabled_plans_count => 2)
+    result = run_check(subject)
+    assert result.fail?
+    assert_match 'There are 2 disabled sync plans which needs to be enabled', result.output
+    assert_equal [Procedures::SyncPlans::Enable], subject.next_steps.map(&:class)
+  end
+end

--- a/test/definitions/checks/sync_plans/with_enabled_status_test.rb
+++ b/test/definitions/checks/sync_plans/with_enabled_status_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+describe Checks::SyncPlans::WithEnabledStatus do
+  include DefinitionsTestHelper
+
+  subject do
+    Checks::SyncPlans::WithEnabledStatus.new
+  end
+
+  it 'passes when no active sync plans' do
+    assume_feature_present(:sync_plans, :active_sync_plans_count => 0)
+    result = run_check(subject)
+    assert result.success?
+  end
+
+  it 'fails when active sync plans are present' do
+    assume_feature_present(:sync_plans, :active_sync_plans_count => 2)
+    result = run_check(subject)
+    assert result.fail?
+    assert_match 'There are total 2 active sync plans in the system', result.output
+    assert_equal [Procedures::SyncPlans::Disable], subject.next_steps.map(&:class)
+  end
+end

--- a/test/lib/yaml_storage_test.rb
+++ b/test/lib/yaml_storage_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module ForemanMaintain
+  describe YamlStorage do
+    let :storage_sample do
+      YamlStorage.new(:post_upgrade, :key => 'test data')
+    end
+
+    def nested_hash_value(obj, key)
+      if obj.respond_to?(:key?) && obj.key?(key)
+        obj[key]
+      elsif obj.respond_to?(:each)
+        matching_obj = nil
+        obj.find { |*o| matching_obj = nested_hash_value(o.last, key) }
+        matching_obj
+      end
+    end
+
+    before do
+      file_path = YamlStorage.storage_file_path
+      File.delete(file_path) if File.exist?(file_path)
+    end
+
+    it 'Empty hash for key which is not present' do
+      details = ForemanMaintain.storage(:test_upgrade)
+      assert_equal(:test_upgrade, details.sub_key, 'expected sub_key should be match')
+      assert_equal({}, details.data, 'expected empty hash')
+    end
+
+    it 'saves data to file using save method' do
+      old_storage = ForemanMaintain.storage(:upgrade)
+      sp_data = { :enabled => [], :disabled => [1] }
+      old_storage[:sync_plans] = sp_data
+      old_storage.save
+      assert_equal(YamlStorage, old_storage.class, 'expected YamlStorage object')
+      new_storage = ForemanMaintain.storage(:upgrade)
+      sp_new_data = nested_hash_value(new_storage.data, :sync_plans)
+      assert_equal([1], sp_new_data[:disabled], 'expected values should be match')
+    end
+
+    it 'returns YamlStorage object using load method' do
+      YamlStorage.instance_variable_set('@storage_register',
+                                        :post_upgrade => { :key => 'test data' })
+      yml_storage_obj = YamlStorage.load(:post_upgrade)
+      assert_equal storage_sample.class, yml_storage_obj.class
+      storage_sample.sub_key.must_equal yml_storage_obj.sub_key
+      storage_sample.data.must_equal yml_storage_obj.data
+    end
+  end
+end


### PR DESCRIPTION
With this commit, below changes included -
1. Two new checks
   - Disable sync plans before upgrade
   - Enable sync plans after upgrade which are disabled previously.

2. Created directory lib/foreman_maintain/storage in which
   using singleton objects we can store data in yaml.

3. Added new config attribute :storage_file to mention file name
   to store data.