### PR TITLE
RFE #16 - Delete invalid tasks

### DIFF
--- a/definitions/checks/foreman_tasks/invalid/check_old.rb
+++ b/definitions/checks/foreman_tasks/invalid/check_old.rb
@@ -1,0 +1,20 @@
+module Checks::ForemanTasks
+  module Invalid
+    class CheckOld < ForemanMaintain::Check
+      metadata do
+        label :check_old_foreman_tasks
+        for_feature :foreman_tasks
+        tags :pre_upgrade
+        description 'Check for old tasks in paused/stopped state'
+      end
+
+      def run
+        # Check and delete 'all tasks beyond 30 days(paused and stopped)'
+        count_old_tasks = feature(:foreman_tasks).count(:old)
+        assert(count_old_tasks <= 0,
+               "Found #{count_old_tasks} paused or stopped task(s) older than 30 days",
+               :next_steps => Procedures::ForemanTasks::Delete.new(:state => :old))
+      end
+    end
+  end
+end

--- a/definitions/checks/foreman_tasks/invalid/check_pending_state.rb
+++ b/definitions/checks/foreman_tasks/invalid/check_pending_state.rb
@@ -1,0 +1,20 @@
+module Checks::ForemanTasks
+  module Invalid
+    class CheckPendingState < ForemanMaintain::Check
+      metadata do
+        label :check_foreman_tasks_in_pending_state
+        for_feature :foreman_tasks
+        tags :pre_upgrade
+        description 'Check for pending tasks which are safe to delete'
+      end
+
+      def run
+        # Check and delete 'all tasks in pending state'
+        count_tasks_in_pending_state = feature(:foreman_tasks).count(:pending)
+        assert(count_tasks_in_pending_state <= 0,
+               "Found #{count_tasks_in_pending_state} pending task(s) which are safe to delete",
+               :next_steps => Procedures::ForemanTasks::Delete.new(:state => :pending))
+      end
+    end
+  end
+end

--- a/definitions/checks/foreman_tasks/invalid/check_planning_state.rb
+++ b/definitions/checks/foreman_tasks/invalid/check_planning_state.rb
@@ -1,0 +1,20 @@
+module Checks::ForemanTasks
+  module Invalid
+    class CheckPlanningState < ForemanMaintain::Check
+      metadata do
+        label :check_foreman_tasks_in_planning_state
+        for_feature :foreman_tasks
+        tags :pre_upgrade
+        description 'Check for tasks in planning state'
+      end
+
+      def run
+        # Check and delete 'all tasks in planning state'
+        tasks_in_planning_count = feature(:foreman_tasks).count(:planning)
+        assert(tasks_in_planning_count <= 0,
+               "Found #{tasks_in_planning_count} task(s) in planning state",
+               :next_steps => Procedures::ForemanTasks::Delete.new(:state => :planning))
+      end
+    end
+  end
+end

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -1,4 +1,16 @@
 class Features::ForemanTasks < ForemanMaintain::Feature
+  MIN_AGE = 30
+
+  SAFE_TO_DELETE = %w[
+    Actions::Katello::Host::GenerateApplicability
+    Actions::Katello::RepositorySet::ScanCdn
+    Actions::Katello::Host::Hypervisors
+    Actions::Katello::Host::HypervisorsUpdate
+    Actions::Foreman::Host::ImportFacts
+    Actions::Candlepin::ListenOnCandlepinEvents
+    Actions::Katello::EventQueue::Monitor
+  ].freeze
+
   metadata do
     label :foreman_tasks
 
@@ -6,6 +18,17 @@ class Features::ForemanTasks < ForemanMaintain::Feature
       check_min_version('ruby193-rubygem-foreman-tasks', '0.6') ||
         check_min_version('tfm-rubygem-foreman-tasks', '0.7')
     end
+  end
+
+  def backup_tasks(state)
+    backup_table('dynflow_execution_plans', state, 'uuid') { |status| yield(status) }
+    backup_table('dynflow_steps', state) { |status| yield(status) }
+    backup_table('dynflow_actions', state) { |status| yield(status) }
+
+    yield('Backup Tasks [running]')
+    export_csv("SELECT * FROM foreman_tasks_tasks WHERE #{condition(state)}",
+               'foreman_tasks_tasks.csv', state)
+    yield('Backup Tasks [DONE]')
   end
 
   def running_tasks_count
@@ -22,8 +45,86 @@ class Features::ForemanTasks < ForemanMaintain::Feature
         WHERE state IN ('paused')
     SQL
     unless ignored_tasks.empty?
-      sql << "AND label NOT IN (#{ignored_tasks.map { |task| "'#{task}'" }.join(',')})"
+      sql << "AND label NOT IN (#{quotize(ignored_tasks)})"
     end
     feature(:foreman_database).query(sql).first['count'].to_i
+  end
+
+  def count(state)
+    feature(:foreman_database).query(<<-SQL).first['count'].to_i
+     SELECT count(*) AS count FROM foreman_tasks_tasks WHERE #{condition(state)}
+    SQL
+  end
+
+  def delete(state)
+    tasks_condition = condition(state)
+
+    feature(:foreman_database).psql(<<-SQL)
+     BEGIN;
+       DELETE FROM dynflow_steps USING foreman_tasks_tasks WHERE (foreman_tasks_tasks.external_id = dynflow_steps.execution_plan_uuid) AND #{tasks_condition};
+       DELETE FROM dynflow_actions USING foreman_tasks_tasks WHERE (foreman_tasks_tasks.external_id = dynflow_actions.execution_plan_uuid) AND #{tasks_condition};
+       DELETE FROM dynflow_execution_plans USING foreman_tasks_tasks WHERE (foreman_tasks_tasks.external_id = dynflow_execution_plans.uuid) AND #{tasks_condition};
+       DELETE FROM foreman_tasks_tasks WHERE #{tasks_condition};
+     COMMIT;
+    SQL
+
+    count(state)
+  end
+
+  def condition(state)
+    raise 'Invalid State' unless valid(state)
+
+    if state == :old
+      old_tasks_condition
+    else
+      tasks_condition(state)
+    end
+  end
+
+  private
+
+  def backup_dir(state)
+    "/var/lib/foreman/backup-tasks/#{state}/#{Time.now.strftime('%Y-%m-%d_%H-%M-%S')}"
+  end
+
+  def backup_table(table, state, fkey = 'execution_plan_uuid')
+    yield("Backup #{table} [running]")
+    sql = "SELECT #{table}.* FROM foreman_tasks_tasks JOIN #{table} ON\
+       (foreman_tasks_tasks.external_id = #{table}.#{fkey})"
+    export_csv(sql, "#{table}.csv", state)
+    yield("Backup #{table} [DONE]")
+  end
+
+  def export_csv(sql, file_name, state)
+    dir = prepare_for_backup(state)
+    filepath = "#{dir}/#{file_name}"
+    execute("echo \"COPY (#{sql}) TO STDOUT WITH CSV;\" \
+      | su - postgres -c '/usr/bin/psql -d foreman' > #{filepath}")
+    execute("bzip2 -9 #{filepath}")
+  end
+
+  def old_tasks_condition(state = "'stopped', 'paused'")
+    "foreman_tasks_tasks.state IN (#{state}) AND " \
+       "foreman_tasks_tasks.started_at < CURRENT_DATE - INTERVAL '#{MIN_AGE} days'"
+  end
+
+  def prepare_for_backup(state)
+    dir = backup_dir(state)
+    execute("mkdir -p #{dir}")
+    dir
+  end
+
+  def quotize(array)
+    array.map { |el| "'#{el}'" }.join(',')
+  end
+
+  def tasks_condition(state)
+    safe_to_delete_tasks = quotize(SAFE_TO_DELETE)
+    "foreman_tasks_tasks.state = '#{state}' AND " \
+    "foreman_tasks_tasks.label IN (#{safe_to_delete_tasks})"
+  end
+
+  def valid(state)
+    [:old, :planning, :pending].include?(state)
   end
 end

--- a/definitions/procedures/foreman_tasks/delete.rb
+++ b/definitions/procedures/foreman_tasks/delete.rb
@@ -1,0 +1,35 @@
+module Procedures::ForemanTasks
+  class Delete < ForemanMaintain::Procedure
+    def initialize(options = {})
+      @state = options[:state]
+
+      self.class.instance_exec(@state) do |state|
+        metadata do
+          description "Delete #{state} tasks"
+        end
+      end
+    end
+
+    def run
+      with_spinner("Deleting #{@state} task") do |spinner|
+        count_tasks_before = feature(:foreman_tasks).count(@state)
+
+        if count_tasks_before > 0
+          spinner.update "Backup #{@state} tasks"
+
+          feature(:foreman_tasks).backup_tasks(@state) do |backup_progress|
+            spinner.update backup_progress
+          end
+
+          spinner.update "Deleting #{@state} tasks [running]"
+          count_tasks_later = feature(:foreman_tasks).delete(@state)
+          spinner.update "Deleting #{@state} tasks [DONE]"
+        end
+
+        spinner.update(
+          "Deleted #{@state} stopped and paused tasks: #{count_tasks_before - count_tasks_later}"
+        )
+      end
+    end
+  end
+end

--- a/lib/foreman_maintain/utils/disk/device.rb
+++ b/lib/foreman_maintain/utils/disk/device.rb
@@ -2,6 +2,8 @@ module ForemanMaintain
   module Utils
     module Disk
       class Device
+        extend Forwardable
+
         include ForemanMaintain::Concerns::SystemHelpers
 
         EXTERNAL_MOUNT_TYPE = %w[fuseblk nfs].freeze
@@ -10,18 +12,12 @@ module ForemanMaintain
 
         attr_reader :io_device
 
+        def_delegators :io_device, :unit, :read_speed
+
         def initialize(dir)
           @dir = dir
           @name = find_device
           @io_device = init_io_device
-        end
-
-        def unit
-          @unit ||= io_device.unit
-        end
-
-        def read_speed
-          @read_speed ||= io_device.read_speed
         end
 
         def slow_disk_error_msg

--- a/test/definitions/test_helper.rb
+++ b/test/definitions/test_helper.rb
@@ -33,6 +33,14 @@ module DefinitionsTestHelper
   alias run_check run_step
   alias run_procedure run_step
 
+  def mock_with_spinner(definition)
+    mock_spinner = MiniTest::Mock.new
+    mock_spinner.expect(:update, nil)
+
+    definition.stubs(:with_spinner).returns(mock_spinner)
+    mock_spinner
+  end
+
   def version(version_str)
     ForemanMaintain::Concerns::SystemHelpers::Version.new(version_str)
   end


### PR DESCRIPTION
**Sub checks and relevant procedures:**
- Check for old or aged foreman tasks(condition: _Paused_ or _stopped_ tasks beyond **30** days)
  - Procedure invoked: `Procedures::ForemanTasksDelete::Aged`
    - Backup _pausesd_ tasks before cleanup
    - Delete aged tasks

- Check for all tasks in planning state
  - Procedure invoked: `Procedures::ForemanTasksDelete::Planning`
  - Backup tasks in _planning_ state
  - Delete tasks in _planning_ state

---
- refactor device.rb did it as I saw it(sorry to mix-up refactoring in this)