### PR TITLE
Compatiblity with rubocop v0.48.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -53,3 +53,11 @@ Security/YAMLLoad:
 # some proper logging
 Metrics/MethodLength:
   Max: 15
+
+Style/SymbolArray:
+  Description: 'Use %i or %I for arrays of symbols.'
+  StyleGuide: '#percent-i'
+  Enabled: false
+
+Style/InverseMethods:
+  Enabled: false

--- a/foreman_maintain.gemspec
+++ b/foreman_maintain.gemspec
@@ -11,10 +11,8 @@ Gem::Specification.new do |s|
   s.version = ForemanMaintain::VERSION
   s.platform = Gem::Platform::RUBY
   s.summary = 'Foreman maintenance tool belt'
-  s.description = <<DESC
-Provides various features that helps keeping the Foreman/Satellite up and
-running.
-DESC
+  s.description = "Provides various features that helps keeping \
+the Foreman/Satellite up and running."
 
   s.files = Dir['{bin,lib,definitions}/**/*']
   s.extra_rdoc_files = [

--- a/lib/foreman_maintain.rb
+++ b/lib/foreman_maintain.rb
@@ -7,6 +7,7 @@ require 'json'
 require 'logger'
 
 module ForemanMaintain
+  require 'foreman_maintain/core_ext'
   require 'foreman_maintain/concerns/logger'
   require 'foreman_maintain/concerns/finders'
   require 'foreman_maintain/concerns/metadata'

--- a/lib/foreman_maintain/core_ext.rb
+++ b/lib/foreman_maintain/core_ext.rb
@@ -1,0 +1,6 @@
+class String
+  def strip_heredoc
+    indent = scan(/^[ \t]*(?=\S)/).min.size || 0
+    gsub(/^[ \t]{#{indent}}/, '')
+  end
+end

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -11,22 +11,22 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<OUTPUT
-Usage:
-    foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
+      assert_cmd <<-OUTPUT.strip_heredoc
+        Usage:
+            foreman-maintain health [OPTIONS] SUBCOMMAND [ARG] ...
 
-Parameters:
-    SUBCOMMAND                    subcommand
-    [ARG] ...                     subcommand arguments
+        Parameters:
+            SUBCOMMAND                    subcommand
+            [ARG] ...                     subcommand arguments
 
-Subcommands:
-    list                          List the checks based on criteria
-    list-tags                     List the tags to use for filtering checks
-    check                         Run the health checks against the system
+        Subcommands:
+            list                          List the checks based on criteria
+            list-tags                     List the tags to use for filtering checks
+            check                         Run the health checks against the system
 
-Options:
-    -h, --help                    print help
-OUTPUT
+        Options:
+            -h, --help                    print help
+      OUTPUT
     end
 
     describe 'list-checks' do
@@ -34,10 +34,10 @@ OUTPUT
         %w(health list)
       end
       it 'lists the defined checks' do
-        assert_cmd <<OUTPUT
-[external-service-is-accessible] external_service_is_accessible         [pre-upgrade-check]
-[present-service-is-running] present service run check                  [basic]
-OUTPUT
+        assert_cmd <<-OUTPUT.strip_heredoc
+          [external-service-is-accessible] external_service_is_accessible         [pre-upgrade-check]
+          [present-service-is-running] present service run check                  [basic]
+        OUTPUT
       end
     end
 
@@ -46,10 +46,10 @@ OUTPUT
         %w(health list-tags)
       end
       it 'lists the defined tags' do
-        assert_cmd <<OUTPUT
-[basic]
-[pre-upgrade-check]
-OUTPUT
+        assert_cmd <<-OUTPUT.strip_heredoc
+          [basic]
+          [pre-upgrade-check]
+        OUTPUT
       end
     end
 
@@ -80,17 +80,17 @@ OUTPUT
       end
 
       it 'raises errors on empty arguments' do
-        assert_cmd <<OUTPUT, %w(--label)
-ERROR: option '--label': value not specified
+        assert_cmd <<-OUTPUT.strip_heredoc, %w(--label)
+          ERROR: option '--label': value not specified
 
-See: 'foreman-maintain health check --help'
-OUTPUT
+          See: 'foreman-maintain health check --help'
+        OUTPUT
 
-        assert_cmd <<OUTPUT, %w(--tags)
-ERROR: option '--tags': value not specified
+        assert_cmd <<-OUTPUT.strip_heredoc, %w(--tags)
+          ERROR: option '--tags': value not specified
 
-See: 'foreman-maintain health check --help'
-OUTPUT
+          See: 'foreman-maintain health check --help'
+        OUTPUT
       end
     end
   end

--- a/test/lib/cli_test.rb
+++ b/test/lib/cli_test.rb
@@ -11,21 +11,21 @@ module ForemanMaintain
     end
 
     it 'prints help' do
-      assert_cmd <<OUTPUT
-Usage:
-    foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...
+      assert_cmd <<-OUTPUT.strip_heredoc
+        Usage:
+            foreman-maintain [OPTIONS] SUBCOMMAND [ARG] ...
 
-Parameters:
-    SUBCOMMAND                    subcommand
-    [ARG] ...                     subcommand arguments
+        Parameters:
+            SUBCOMMAND                    subcommand
+            [ARG] ...                     subcommand arguments
 
-Subcommands:
-    health                        Health related commands
-    upgrade                       Upgrade related commands
+        Subcommands:
+            health                        Health related commands
+            upgrade                       Upgrade related commands
 
-Options:
-    -h, --help                    print help
-OUTPUT
+        Options:
+            -h, --help                    print help
+      OUTPUT
     end
   end
 end

--- a/test/lib/detector_test.rb
+++ b/test/lib/detector_test.rb
@@ -10,22 +10,22 @@ module ForemanMaintain
 
     it 'detects features on the system based on #confine block' do
       features = detector.available_features
-      assert features.find { |f| f.class == Features::PresentService },
-             'failed to collect features that were initialized in `confine` block'
+      assert(features.find { |f| f.class == Features::PresentService },
+             'failed to collect features that were initialized in `confine` block')
 
       TestHelper.use_present_service_2 = true
       detector.refresh
       features = detector.available_features
-      assert features.find { |f| f.class == Features::PresentService2 },
-             'failed to collect newer version of a feature'
+      assert(features.find { |f| f.class == Features::PresentService2 },
+             'failed to collect newer version of a feature')
     end
 
     it 'allows confining one feature based on present of other' do
       features = detector.available_features
-      assert features.find { |f| f.class == Features::Server },
-             'failed to collect features that were initialized in `confine` block'
-      refute features.find { |f| f.class == Features::Client },
-             'failed to detect feature that reference another feature in `confine` block'
+      assert(features.find { |f| f.class == Features::Server },
+             'failed to collect features that were initialized in `confine` block')
+      refute(features.find { |f| f.class == Features::Client },
+             'failed to detect feature that reference another feature in `confine` block')
     end
 
     it 'allows to filter checks based on label or class ===' do

--- a/test/lib/reporter_test.rb
+++ b/test/lib/reporter_test.rb
@@ -37,15 +37,15 @@ module ForemanMaintain
 
       reporter.after_scenario_finishes(scenario)
 
-      assert_equal <<STR, captured_out
-Running present_service upgrade scenario
---------------------------------------------------------------------------------
-present service run check:                                            [OK]
---------------------------------------------------------------------------------
-present service run check:                                            [FAIL]
-The service is not running
---------------------------------------------------------------------------------
-STR
+      assert_equal <<-STR.strip_heredoc, captured_out
+        Running present_service upgrade scenario
+        --------------------------------------------------------------------------------
+        present service run check:                                            [OK]
+        --------------------------------------------------------------------------------
+        present service run check:                                            [FAIL]
+        The service is not running
+        --------------------------------------------------------------------------------
+      STR
     end
 
     it 'asks about the next steps' do
@@ -61,12 +61,12 @@ STR
       will_press('2')
       runner_mock.expect(:add_step, nil, [restart_step])
       reporter.on_next_steps(runner_mock, [start_step, restart_step])
-      assert_equal <<STR.strip, captured_out(false).strip
-There are multiple steps to proceed:
-1) start the present service
-2) restart present service
-Select step to continue, (q) for quit
-STR
+      assert_equal <<-STR.strip_heredoc.strip, captured_out(false).strip
+        There are multiple steps to proceed:
+        1) start the present service
+        2) restart present service
+        Select step to continue, (q) for quit
+      STR
 
       will_press('q')
       runner_mock.expect(:ask_to_quit, nil)


### PR DESCRIPTION
1. Disabled: Use %i or %I for an array of symbols
2. Fixed: Use 2 spaces for indentation in a heredoc by using some library(e.g. ActiveSupport's String#strip_heredoc). Created `foreman_maintain/core_ext.rb` extend String class.
3. Fixed: Parenthesize the param find to make sure that the block will be associated with the assert/refute method call.
4. Fixed: Use >= instead of inverting <.

Following offense fixed by disabling IverseMethods check:

```ruby
lib/foreman_maintain/concerns/metadata.rb:62:11: C: Use >= instead of inverting <.
          !(superclass < Metadata)
```

Disabled `InverseMethod` rubocop check:
```yaml
Style/InverseMethods:
  Enabled: false
```