### PR TITLE
Rerun the check after a procedure

### DIFF
--- a/lib/foreman_maintain/executable.rb
+++ b/lib/foreman_maintain/executable.rb
@@ -3,6 +3,7 @@ module ForemanMaintain
     extend Forwardable
     def_delegators :execution, :success?, :fail?, :output
     def_delegators :execution, :puts, :print, :with_spinner, :ask
+
     attr_accessor :associated_feature
 
     def associated_feature
@@ -12,15 +13,15 @@ module ForemanMaintain
       end
     end
 
-    # public method to be overriden
-    def run
-      raise NotImplementedError
-    end
-
     # next steps to be offered to the user after the step is run
     # It can be added for example from the assert method
     def next_steps
       @next_steps ||= []
+    end
+
+    # public method to be overriden
+    def run
+      raise NotImplementedError
     end
 
     def execution
@@ -43,7 +44,7 @@ module ForemanMaintain
 
     # internal method called by executor
     def __run__(execution)
-      @_execution = execution
+      setup_execution_state(execution)
       run
     end
 
@@ -51,6 +52,13 @@ module ForemanMaintain
     # even when the definitions provide us only class
     def ensure_instance
       self
+    end
+
+    # clean the execution-specific state to prepare for the next execution
+    # attempts
+    def setup_execution_state(execution)
+      @_execution = execution
+      @next_steps = []
     end
 
     class << self

--- a/lib/foreman_maintain/runner.rb
+++ b/lib/foreman_maintain/runner.rb
@@ -17,7 +17,7 @@ module ForemanMaintain
         execution = Execution.new(step, @reporter)
         execution.run
         @executions << execution
-        ask_about_offered_steps(step.next_steps)
+        ask_about_offered_steps(step)
       end
       @reporter.after_scenario_finishes(@scenario)
     end
@@ -26,23 +26,27 @@ module ForemanMaintain
       @quit = true
     end
 
-    def add_step(step)
-      @steps_to_run.unshift(step)
+    def add_steps(*steps)
+      # we we add the steps at the beginning, but still keeping the
+      # order of steps passed in the arguments
+      steps.reverse.each do |step|
+        @steps_to_run.unshift(step)
+      end
     end
 
     private
 
-    def ask_about_offered_steps(steps)
-      if steps && !steps.empty?
-        steps = steps.map(&:ensure_instance)
+    def ask_about_offered_steps(step)
+      if step.next_steps && !step.next_steps.empty?
+        steps = step.next_steps.map(&:ensure_instance)
         decision = @reporter.on_next_steps(steps)
         case decision
         when :quit
           ask_to_quit
         when Executable
-          add_step(decision)
-        else
-          raise "Unexpected decision #{decision}" unless decision == :no
+          chosen_steps = [decision]
+          chosen_steps << step if step.is_a?(Check)
+          add_steps(*chosen_steps)
         end
       end
     end

--- a/test/lib/runner_test.rb
+++ b/test/lib/runner_test.rb
@@ -15,6 +15,7 @@ module ForemanMaintain
     end
 
     it 'performs all steps in the scenario' do
+      reporter.planned_next_steps_answers = %w[y n]
       runner.run
       assert_equal([['before_scenario_starts', 'present_service upgrade scenario'],
                     ['before_execution_starts', 'present service run check'],
@@ -22,8 +23,9 @@ module ForemanMaintain
                     ['on_next_steps', 'start the present service'],
                     ['before_execution_starts', 'start the present service'],
                     ['after_execution_finishes', 'start the present service'],
-                    ['before_execution_starts', 'restart present service'],
-                    ['after_execution_finishes', 'restart present service'],
+                    ['before_execution_starts', 'present service run check'],
+                    ['after_execution_finishes', 'present service run check'],
+                    ['on_next_steps', 'start the present service'],
                     ['after_scenario_finishes', 'present_service upgrade scenario']],
                    reporter.log,
                    'unexpected order of execution')

--- a/test/lib/support/log_reporter.rb
+++ b/test/lib/support/log_reporter.rb
@@ -1,10 +1,12 @@
 class Support
   class LogReporter < ForemanMaintain::Reporter
     attr_reader :log, :output
+    attr_accessor :planned_next_steps_answers
 
     def initialize
       @log = []
       @output = ''
+      @planned_next_steps_answers = []
     end
 
     def log_method(method, *args)
@@ -30,7 +32,17 @@ class Support
 
     def on_next_steps(steps)
       @log << [__method__.to_s].concat(stringified_args(*steps))
-      steps.first
+      next_answer = @planned_next_steps_answers.shift
+      case next_answer
+      when 'y'
+        steps.first
+      when 'n', nil
+        :quit
+      when /\d/
+        steps[next_answer.to_i - 1]
+      else
+        raise "Unexpected next answer #{next_answer}"
+      end
     end
 
     def stringified_args(*args)


### PR DESCRIPTION
When user chooses a procedure, we now re-run the check again to make sure the
issue if resolved. This allows to repeat the check/fix cycle several times:
also the multiple steps for procedures make more sense now.