### PR TITLE
Fixes #44 - Rename tag 'basic' to 'default'

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ class Checks::ForemanIsRuning < ForemanMaintain::Check
 
   description 'check foreman service is running'
 
-  tags :basic
+  tags :default
 
   def run
     # we are using methods of a feature.
@@ -157,7 +157,7 @@ class Scenarios::PreUpgradeCheckForeman_1_14 < ForemanMaintain::Scenario
   # Method to be called when composing the steps of the scenario
   def compose
     # we can search for the checks by metadata
-    steps.concat(find_checks(:basic))
+    steps.concat(find_checks(:default))
   end
 end
 ```

--- a/definitions/checks/disk_speed_minimal.rb
+++ b/definitions/checks/disk_speed_minimal.rb
@@ -2,7 +2,7 @@ class Checks::DiskSpeedMinimal < ForemanMaintain::Check
   metadata do
     label :disk_io
     description 'Check for recommended disk speed of pulp, mongodb, pgsql dir.'
-    tags :basic
+    tags :pre_upgrade
 
     confine do
       execute?('which hdparm') && execute?('which fio')

--- a/definitions/checks/foreman_tasks/not_paused.rb
+++ b/definitions/checks/foreman_tasks/not_paused.rb
@@ -3,7 +3,7 @@ module Checks::ForemanTasks
     metadata do
       for_feature :foreman_tasks
       description 'check for paused tasks'
-      tags :basic
+      tags :default
     end
 
     def run

--- a/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
+++ b/definitions/scenarios/pre_upgrade_check_foreman_1_14.rb
@@ -8,6 +8,6 @@ class Scenarios::PreUpgradeCheckForeman_1_14 < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_0_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_0_z < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_1 < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_1_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_1_z < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2.rb
@@ -8,7 +8,8 @@ class Scenarios::PreUpgradeCheckSatellite_6_2 < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_2_z.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_2_z < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
+++ b/definitions/scenarios/pre_upgrade_check_satellite_6_3.rb
@@ -8,7 +8,7 @@ class Scenarios::PreUpgradeCheckSatellite_6_3 < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_steps(find_checks(:pre_upgrade))
   end
 end

--- a/lib/foreman_maintain/cli/health_command.rb
+++ b/lib/foreman_maintain/cli/health_command.rb
@@ -45,7 +45,7 @@ module ForemanMaintain
           if label
             { :label => label }
           else
-            { :tags => tags || [:basic] }
+            { :tags => tags || [:default] }
           end
         end
 

--- a/test/lib/cli/health_command_test.rb
+++ b/test/lib/cli/health_command_test.rb
@@ -36,7 +36,8 @@ module ForemanMaintain
       it 'lists the defined checks' do
         assert_cmd <<-OUTPUT.strip_heredoc
           [external-service-is-accessible] external_service_is_accessible         [pre-upgrade-check]
-          [present-service-is-running] present service run check                  [basic]
+          [present-service-is-running] present service run check                  [default]
+          [service-is-stopped] service not running check                          [default]
         OUTPUT
       end
     end
@@ -47,7 +48,7 @@ module ForemanMaintain
       end
       it 'lists the defined tags' do
         assert_cmd <<-OUTPUT.strip_heredoc
-          [basic]
+          [default]
           [pre-upgrade-check]
         OUTPUT
       end
@@ -67,7 +68,7 @@ module ForemanMaintain
 
       it 'runs the default checks' do
         Cli::HealthCommand.any_instance.expects(:run_scenario).with do |scenario|
-          scenario.filter_tags.must_equal [:basic]
+          scenario.filter_tags.must_equal [:default]
         end
         run_cmd
       end

--- a/test/lib/detector_test.rb
+++ b/test/lib/detector_test.rb
@@ -42,7 +42,7 @@ module ForemanMaintain
     end
 
     it 'allows to filter checks based on metadata and present features' do
-      checks = detector.available_checks(:basic)
+      checks = detector.available_checks(:default)
       assert_includes(checks, Checks::PresentServiceIsRunning,
                       'checks that should be found is missing')
       refute_includes(checks, Checks::MissingServiceIsRunning,

--- a/test/lib/support/definitions/checks/missing_service_is_running.rb
+++ b/test/lib/support/definitions/checks/missing_service_is_running.rb
@@ -2,7 +2,7 @@ class Checks::MissingServiceIsRunning < ForemanMaintain::Check
   metadata do
     # simulate a check defined for service that is not present on the system
     for_feature(:missing_service)
-    tags :basic
+    tags :default
     description 'missing service is running check'
   end
 

--- a/test/lib/support/definitions/checks/present_service_is_running.rb
+++ b/test/lib/support/definitions/checks/present_service_is_running.rb
@@ -2,7 +2,7 @@ class Checks::PresentServiceIsRunning < ForemanMaintain::Check
   metadata do
     label :present_service_is_running
     for_feature(:present_service)
-    tags :basic
+    tags :default
     description 'present service run check'
   end
 

--- a/test/lib/support/definitions/checks/service_is_stopped.rb
+++ b/test/lib/support/definitions/checks/service_is_stopped.rb
@@ -1,0 +1,13 @@
+class Checks::ServiceIsStopped < ForemanMaintain::Check
+  metadata do
+    for_feature(:present_service)
+    label :service_is_stopped
+    tags :default
+    description 'service not running check'
+  end
+
+  def run
+    assert(false, 'service is running',
+           :next_steps => Procedures::StopService.new)
+  end
+end

--- a/test/lib/support/definitions/features/present_service.rb
+++ b/test/lib/support/definitions/features/present_service.rb
@@ -11,6 +11,10 @@ class Features::PresentService < ForemanMaintain::Feature
     # pretend we start the service
   end
 
+  def stop
+    # pretend we stop the service
+  end
+
   def restart
     # pretend we restart the service
   end

--- a/test/lib/support/definitions/procedures/missing_service_restart.rb
+++ b/test/lib/support/definitions/procedures/missing_service_restart.rb
@@ -1,7 +1,7 @@
 class Procedures::MissingServiceRestart < ForemanMaintain::Procedure
   metadata do
     for_feature(:missing_service)
-    tags :basic
+    tags :default
     description 'restart missing service'
   end
 

--- a/test/lib/support/definitions/procedures/stop_service.rb
+++ b/test/lib/support/definitions/procedures/stop_service.rb
@@ -1,0 +1,10 @@
+class Procedures::StopService < ForemanMaintain::Procedure
+  metadata do
+    for_feature(:present_service)
+    description 'stop the running service'
+  end
+
+  def run
+    feature(:present_service).stop
+  end
+end

--- a/test/lib/support/definitions/scenarios/missing_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/missing_upgrade.rb
@@ -8,6 +8,6 @@ class Scenarios::MissingUpgrade < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
   end
 end

--- a/test/lib/support/definitions/scenarios/present_upgrade.rb
+++ b/test/lib/support/definitions/scenarios/present_upgrade.rb
@@ -9,7 +9,7 @@ class Scenarios::PresentUpgrade < ForemanMaintain::Scenario
   end
 
   def compose
-    add_steps(find_checks(:basic))
+    add_steps(find_checks(:default))
     add_step(procedure(Procedures::PresentServiceRestart))
   end
 end


### PR DESCRIPTION
1. Rename tag `basic` to `default`.
2. Disk speed-check to be tagged as `pre-upgrade`.
3. Default tag in action for health check command will be `default`.