### PR TITLE
Fixes #59 - missing error for hammer-config file

### DIFF
--- a/definitions/checks/foreman_tasks/not_paused.rb
+++ b/definitions/checks/foreman_tasks/not_paused.rb
@@ -1,5 +1,6 @@
 module Checks::ForemanTasks
   class NotPaused < ForemanMaintain::Check
+    include ForemanMaintain::Concerns::Hammer
     metadata do
       for_feature :foreman_tasks
       description 'check for paused tasks'

--- a/definitions/features/foreman_tasks.rb
+++ b/definitions/features/foreman_tasks.rb
@@ -82,6 +82,10 @@ class Features::ForemanTasks < ForemanMaintain::Feature
     end
   end
 
+  def resume_task_using_hammer
+    hammer('task resume')
+  end
+
   private
 
   def backup_dir(state)

--- a/definitions/procedures/foreman_tasks/resume.rb
+++ b/definitions/procedures/foreman_tasks/resume.rb
@@ -1,14 +1,12 @@
 module Procedures::ForemanTasks
   class Resume < ForemanMaintain::Procedure
-    include ForemanMaintain::Concerns::Hammer
-
     metadata do
       for_feature :foreman_tasks
       description 'resume paused tasks'
     end
 
     def run
-      output << hammer('task resume')
+      output << feature(:foreman_tasks).resume_task_using_hammer
     end
   end
 end

--- a/test/definitions/procedures/foreman_tasks/resume_test.rb
+++ b/test/definitions/procedures/foreman_tasks/resume_test.rb
@@ -8,7 +8,7 @@ describe Procedures::ForemanTasks::Resume do
   end
 
   it 'passes calls hammer to resume the tasks' do
-    subject.expects(:hammer).with('task resume').returns('5 tasks resumed')
+    assume_feature_present(:foreman_tasks, :resume_task_using_hammer => '5 tasks resumed')
     result = run_procedure(subject)
     assert result.success?, 'the procedure was expected to succeed'
     assert_equal result.output, '5 tasks resumed'


### PR DESCRIPTION
As we already have foreman-tasks feature, moved hammer code from resume procedure to feature file.
Which will ask hammer credentials instead of showing error message for missing config file.


